### PR TITLE
Remove password authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,14 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: %i[google_oauth2]
+  devise :omniauthable, omniauth_providers: %i[google_oauth2]
 
   has_many :llm_api_keys, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
+
+  def self.from_omniauth(auth)
+    where(email: auth.info.email).first_or_create do |user|
+      user.email = auth.info.email
+      user.google_id = auth.uid
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :llm_api_keys, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
+  validates :google_id, presence: true, uniqueness: true
 
   def self.from_omniauth(auth)
     where(email: auth.info.email).first_or_create do |user|

--- a/db/migrate/20250905004329_remove_password_fields_from_users.rb
+++ b/db/migrate/20250905004329_remove_password_fields_from_users.rb
@@ -1,0 +1,8 @@
+class RemovePasswordFieldsFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :encrypted_password, :string
+    remove_column :users, :reset_password_token, :string
+    remove_column :users, :reset_password_sent_at, :datetime
+    remove_column :users, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_04_062508) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_05_004329) do
   create_table "llm_api_keys", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "llm_type", null: false
@@ -39,16 +39,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_04_062508) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.string "google_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["google_id"], name: "index_users_on_google_id", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "llm_api_keys", "users"

--- a/test/models/llm_api_key_test.rb
+++ b/test/models/llm_api_key_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class LlmApiKeyTest < ActiveSupport::TestCase
   test "should create valid llm_api_key with required attributes" do
     user = User.create!(
-      email: "test@example.com"
+      email: "test@example.com",
+      google_id: 1
     )
 
     llm_api_key = LlmApiKey.new(
@@ -31,7 +32,8 @@ class LlmApiKeyTest < ActiveSupport::TestCase
 
   test "should require unique uuid" do
     user = User.create!(
-      email: "test2@example.com"
+      email: "test2@example.com",
+      google_id: 2
     )
     uuid = SecureRandom.uuid
 

--- a/test/models/llm_api_key_test.rb
+++ b/test/models/llm_api_key_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class LlmApiKeyTest < ActiveSupport::TestCase
   test "should create valid llm_api_key with required attributes" do
     user = User.create!(
-      email: "test@example.com",
-      password: "password123"
+      email: "test@example.com"
     )
 
     llm_api_key = LlmApiKey.new(
@@ -32,8 +31,7 @@ class LlmApiKeyTest < ActiveSupport::TestCase
 
   test "should require unique uuid" do
     user = User.create!(
-      email: "test2@example.com",
-      password: "password123"
+      email: "test2@example.com"
     )
     uuid = SecureRandom.uuid
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,21 +1,34 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  test "valid user with email" do
-    user = User.new(email: "test@example.com")
+  test "valid user with email, google_id" do
+    user = User.new(email: "test@example.com", google_id: 1)
     assert user.valid?
   end
 
   test "invalid user without email" do
-    user = User.new
+    user = User.new(google_id: 1)
     assert_not user.valid?
     assert_includes user.errors[:email], "can't be blank"
   end
 
-  test "invalid user with duplicate email" do
-    User.create!(email: "test@example.com")
+  test "invalid user without google_id" do
     user = User.new(email: "test@example.com")
     assert_not user.valid?
+    assert_includes user.errors[:google_id], "can't be blank"
+  end
+
+  test "invalid user with duplicate email" do
+    User.create!(email: "test@example.com", google_id: 1)
+    user = User.new(email: "test@example.com", google_id: 2)
+    assert_not user.valid?
     assert_includes user.errors[:email], "has already been taken"
+  end
+
+  test "invalid user with duplicate google_id" do
+    User.create!(email: "test1@example.com", google_id: 1)
+    user = User.new(email: "test2@example.com", google_id: 1)
+    assert_not user.valid?
+    assert_includes user.errors[:google_id], "has already been taken"
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,19 +2,19 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   test "valid user with email" do
-    user = User.new(email: "test@example.com", password: "password123")
+    user = User.new(email: "test@example.com")
     assert user.valid?
   end
 
   test "invalid user without email" do
-    user = User.new(password: "password123")
+    user = User.new
     assert_not user.valid?
     assert_includes user.errors[:email], "can't be blank"
   end
 
   test "invalid user with duplicate email" do
-    User.create!(email: "test@example.com", password: "password123")
-    user = User.new(email: "test@example.com", password: "password123")
+    User.create!(email: "test@example.com")
+    user = User.new(email: "test@example.com")
     assert_not user.valid?
     assert_includes user.errors[:email], "has already been taken"
   end


### PR DESCRIPTION
## 概要

ユーザーログインでのパスワード認証は使用しない（Google シングルサインオンのみ使用する）ため、
パスワード関連のカラムを削除します。