### PR TITLE
Set configure_permitted_parameters in before_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,13 @@ class ApplicationController < ActionController::Base
 
   # Devise authentication
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  # Devise permitted parameters setting
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :google_id ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :google_id ])
+  end
 end


### PR DESCRIPTION
## 概要

すべてのコントローラーに、前処理（before_action）として devise_parameter_sanitizer で許可する項目をセットするようにします。