### PR TITLE
Allows POST method only in OmniAuth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,4 @@
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  OmniAuth.config.allowed_request_methods = [ :post ]
+end


### PR DESCRIPTION
## 概要

OmniAuth の設定を追加しました。

CSRFアタック対策として、POSTメソッドを許可し、GETメソッドを不許可とします。

## 変更理由

現在GETメソッドのみで実装されているOAuth認証にセキュリティ上の脆弱性が存在するため。

## 現在の問題点

CSRF（Cross-Site Request Forgery）攻撃のリスク

```
<!-- 悪意のあるサイトがこのタグを仕込むだけで -->
<img src="https://our-site.com/auth/google">
<!-- ユーザーが意図せずに認証処理が開始されてしまう -->
```

- ユーザーが悪意のあるサイトを閲覧するだけで、勝手にOAuth認証が開始される
- アカウント乗っ取りや不正ログインにつながる可能性

## 解決方法

POSTメソッドのみに制限することで：

- 画像タグやリンククリックによる意図しない認証開始を完全に防止
- OAuth2のベストプラクティスに準拠（OAuth2.1仕様準拠）
- 業界標準のセキュリティレベルを実現（GitHub、Google、Microsoft等と同等）

## 影響範囲

- ユーザー体験: 変更なし（今後ログインボタンはPOSTで実装する）
- 既存機能: 要確認 - GETでのアクセスは全て無効となる
- セキュリティ: 大幅に向上（CSRF攻撃を完全に防止）

## 緊急度

中程度（現在攻撃を受けているわけではないが、潜在的リスクを完全排除）

## 注意事項

この変更により、`/auth/google` へのGETリクエストは全て403エラーとなります。