### PR TITLE
Install fontawesome 7.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,6 @@ gem "aws-sdk-kms"
 # Load environment variables from .env file
 gem "dotenv-rails"
 
-# FontAwesome icons
-gem "font-awesome-rails", "~> 4.7", ">= 4.7.0.9"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,8 +140,6 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    font-awesome-rails (4.7.0.9)
-      railties (>= 3.2, < 9.0)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -463,7 +461,6 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
-  font-awesome-rails (~> 4.7, >= 4.7.0.9)
   httparty
   importmap-rails
   jbuilder

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,7 +8,3 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
-
-/*
- *= require font-awesome
- */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <%# FontAwesome 7.0.1 CDN (provided cdnjs) %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>


### PR DESCRIPTION
## 概要

gem `font-awesome-rails` は古いバージョンのFontAwesomeを使用しているため、Webで確認できるアイコン識別子と差異が生じ使いづらいです。

そこで最新のFontAwesome 7.0.1を使うようにします。FontAwesome の公式CDNは廃止されましたが、cdnjsが代わりに提供してくれているので、これを利用します。https://cdnjs.com/libraries/font-awesome