### PR TITLE
Add sign out link on global navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,12 @@
                   <span class="mr-1"><%= current_user.email %></span>
                   <i class="fa-solid fa-chevron-down h-4 w-4"></i>
                 </button>
-
                 <div popover id="menu-popover">
+                  <%= form_with url: user_logout_path, method: :post, local: true, class: "w-full", data: { turbo: false } do |form| %>
+                    <%= button_tag type: "submit", class: "block px-4 py-2 w-full text-sm text-gray-700 hover:bg-gray-100" do %>
+                      <i class="fa-brands fa-google mr-2"></i>Sign out
+                    <% end %>
+                  <% end %>
                 </div>
               </div>
             <% else %>


### PR DESCRIPTION
## 概要

グローバルナビゲーションのドロップダウンメニューにサインアウトリンクを追加します。

## 外観

<img width="404" height="133" alt="image" src="https://github.com/user-attachments/assets/21bf3867-8684-4a49-beeb-8916d126f352" />
