### PR TITLE
Changed sign out icon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
                 <div popover id="menu-popover">
                   <%= form_with url: user_logout_path, method: :post, local: true, class: "w-full", data: { turbo: false } do |form| %>
                     <%= button_tag type: "submit", class: "block px-4 py-2 w-full text-sm text-gray-700 hover:bg-gray-100" do %>
-                      <i class="fa-brands fa-google mr-2"></i>Sign out
+                      <i class="fa-solid fa-arrow-right-from-bracket"></i> Sign out
                     <% end %>
                   <% end %>
                 </div>


### PR DESCRIPTION
## 概要

グローバルナビゲーションの右上のドロップダウンメニュー内のサインアウトメニューのアイコンを変更します。

理由：Googleアカウントからサインアウトするのではないかと誤解が生じる可能性があるため。

Before:
<img width="480" height="182" alt="image" src="https://github.com/user-attachments/assets/c81c0083-4fec-4b54-9919-097f9c3c6e55" />


After:
<img width="479" height="195" alt="image" src="https://github.com/user-attachments/assets/4120c12e-36d4-4239-85be-917db78004f5" />
