### PR TITLE
Add a migration to rebuild the index

### DIFF
--- a/db/migrate/20250918075907_remove_unique_index_from_llm_api_keys.rb
+++ b/db/migrate/20250918075907_remove_unique_index_from_llm_api_keys.rb
@@ -1,0 +1,9 @@
+class RemoveUniqueIndexFromLlmApiKeys < ActiveRecord::Migration[8.0]
+  def change
+    # Remove unique index defined in 20250904062508_create_llm_api_keys.rb
+    remove_index :llm_api_keys, [ :user_id, :llm_type ]
+
+    # Add regular index without unique constraint
+    add_index :llm_api_keys, [ :user_id, :llm_type ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_05_004329) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_18_075907) do
   create_table "llm_api_keys", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "llm_type", null: false
@@ -18,7 +18,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_05_004329) do
     t.string "uuid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "llm_type"], name: "index_llm_api_keys_on_user_id_and_llm_type", unique: true
+    t.index ["user_id", "llm_type"], name: "index_llm_api_keys_on_user_id_and_llm_type"
     t.index ["user_id"], name: "index_llm_api_keys_on_user_id"
     t.index ["uuid"], name: "index_llm_api_keys_on_uuid", unique: true
   end


### PR DESCRIPTION
## 概要

ユニーク制約付き `(:user_id, :llm_type)` のインデックスを、ユニーク制約なしで作り直します。

理由：同じ種類のLLMサービスのAPI キーを複数持ち、使い分けることが想定できるため。ユニーク制約付きだとそれが実現できない。