### PR TITLE
Add description validation in llm_api_key model

### DIFF
--- a/app/models/llm_api_key.rb
+++ b/app/models/llm_api_key.rb
@@ -4,4 +4,5 @@ class LlmApiKey < ApplicationRecord
   validates :uuid, presence: true, uniqueness: true
   validates :llm_type, presence: true
   validates :encrypted_api_key, presence: true
+  validates :description, length: { maximum: 255 }, allow_blank: true
 end


### PR DESCRIPTION
## 概要

`llm_api_key` モデルに `description` カラムに対する最大255字制限のバリデーションを追加します。