### PR TITLE
Enable SolidCache in development environment

### DIFF
--- a/config/cache.yml
+++ b/config/cache.yml
@@ -6,6 +6,7 @@ default: &default
     namespace: <%= Rails.env %>
 
 development:
+  database: cache
   <<: *default
 
 test:

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,8 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  cache:
+    <<: *default
+    database: storage/development_cache.sqlite3
+    migrations_paths: db/cache_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,8 +25,8 @@ Rails.application.configure do
     config.action_controller.perform_caching = false
   end
 
-  # Change to :null_store to avoid any caching.
-  config.cache_store = :memory_store
+  # Use a different cache store in production.
+  config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local


### PR DESCRIPTION
## 概要

Solid Cacheが正しく動作するかを検証時に確認しておきたいため、
ApiKeyManagerクラスを実装する際に使用するSolid CacheをDevelopment環境でも有効にします。

Production環境ではすでに有効化されているようです。