### PR TITLE
Implemented plain_api_key method

### DIFF
--- a/app/models/llm_api_key.rb
+++ b/app/models/llm_api_key.rb
@@ -9,6 +9,10 @@ class LlmApiKey < ApplicationRecord
 
   before_validation :set_uuid, :encrypt_api_key
 
+  def plain_api_key
+    ApiKeyDecrypter.new.decrypt(encrypted_api_key) if encrypted_api_key.present?
+  end
+
   private
 
   def set_uuid


### PR DESCRIPTION
## 概要

`llm_api_key` モデルに `plain_api_key` メソッドを実装しました。

これは `ApiKeyManager` クラスから呼び出される予定です。