### PR TITLE
Fix gemini behavior

### DIFF
--- a/config/initializers/llm_gemini_patch.rb
+++ b/config/initializers/llm_gemini_patch.rb
@@ -11,6 +11,7 @@ module LLM
       action = stream ? "streamGenerateContent?key=#{@key}&alt=sse" : "generateContent?key=#{@key}"
 
       # It seems strange that there's no left operand in an expression using a ternary operator.
+      # https://github.com/llmrb/llm/blob/d92c133f48accac5f15e3c5090b4e0d8ba41cdf5/lib/llm/providers/gemini.rb#L74
       model = model.respond_to?(:id) ? model.id : model
 
       path = [ "/v1beta/models/#{model}", action ].join(":")


### PR DESCRIPTION
## 概要

Gemini LLM利用時の特殊な振る舞いを吸収します。

1.  ~~`available_models_for` 実行時に `models/*****` 形式でモデル名が返されるのを吸収~~
2.  ~~`find_model_id` でモデル名を検索する時に、`models/****` に直してモデル名が一致するように吸収~~
3.  ~~`find_model_id` でリターン時に `models/*****` 形式ではなく、接頭辞 `models/` を外すように吸収~~

~~3については、以下のllm.rb の内部実装により、Models API で受け取ったmodel id をそのままcompletion API に渡すと~~
~~パスが`/v1beta/models/models/***** ～` のように組み立てられNotFoundになる問題があり、それを吸収しています。~~
https://github.com/llmrb/llm/blob/d92c133f48accac5f15e3c5090b4e0d8ba41cdf5/lib/llm/providers/gemini.rb#L75