### PR TITLE
Fix gemini models api

### DIFF
--- a/config/initializers/llm_gemini_patch.rb
+++ b/config/initializers/llm_gemini_patch.rb
@@ -27,6 +27,7 @@ module LLM
   end
 end
 
+# Original code: https://github.com/llmrb/llm/blob/d9a126c89df698f29a156229db8d4a6fd049f330/lib/llm/providers/gemini/response/models.rb#L3-L15
 module LLM::Gemini::Response
   module Models
     include ::Enumerable


### PR DESCRIPTION
## 概要

module LLM::Gemini::Response::Models にモンキーパッチを当てて、**他のLLMサービス** との差異を吸収します。

### 他のLLMサービスとの差異

* 他のLLMは `model.id` でモデル名を取得するが、Geminiでは `model.name` で取得しなければならなかった。
* 他のLLMのモデル名には接頭辞はついていないが、Geminiではモデル名の接頭辞として "models/"がついていた。