### PR TITLE
Wire tool selection and MCP error handling into chats endpoint

### DIFF
--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -3,22 +3,26 @@ class Api::ChatsController < ApiController
   rescue_from LLM::RateLimitError, with: :rate_limit_error
   rescue_from LlmApiKeyRequiredError, with: :api_key_required_error
   rescue_from ArgumentError, with: :argument_error
+  rescue_from McpClient::McpConnectionError, with: :mcp_connection_error
+  rescue_from McpClient::McpProtocolError, with: :mcp_protocol_error
 
   def create
     uuid, model_name, prompt = expected_params
+
     if bearer_token
       llm_api_key = current_user.find_llm_api_key uuid
       model_id = LlmModelMap.fetch! model_name, llm_type: llm_api_key&.llm_type
-      message = LlmRbFacade.call! model_id, prompt, llm_api_key: llm_api_key
+      tools = selected_tools
+      message = LlmRbFacade.call! model_id, prompt,
+        llm_api_key: llm_api_key,
+        tools: tools
     else
       model_id = LlmModelMap.fetch! model_name
       message = LlmRbFacade.call! model_id, prompt
     end
 
     render json: {
-      response: {
-        message: message
-      }
+      response: format_response(message)
     }
   end
 
@@ -36,7 +40,35 @@ class Api::ChatsController < ApiController
     render json: { error: "Invalid arguments", message: exception.message }, status: :bad_request
   end
 
+  def mcp_connection_error(exception)
+    render json: { error: "MCP server connection failed", message: exception.message }, status: :bad_gateway
+  end
+
+  def mcp_protocol_error(exception)
+    render json: { error: "MCP protocol error", message: exception.message }, status: :bad_gateway
+  end
+
   def expected_params
     params.expect(:llm_api_key_uuid, :model_name, :prompt)
+  end
+
+  def selected_tools
+    tool_ids = params[:tool_ids]
+    return [] if tool_ids.blank?
+
+    mcp_tools = current_user.mcp_servers.active
+      .joins(:mcp_tools)
+      .merge(McpTool.active.where(id: tool_ids))
+      .flat_map { it.mcp_tools.active.where(id: tool_ids).includes(:mcp_server) }
+
+    McpToolAdapter.to_llm_functions(mcp_tools)
+  end
+
+  def format_response(result)
+    if result.is_a?(Hash)
+      result
+    else
+      { message: result }
+    end
   end
 end

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -56,12 +56,7 @@ class Api::ChatsController < ApiController
     tool_ids = params[:tool_ids]
     return [] if tool_ids.blank?
 
-    mcp_tools = current_user.mcp_servers.active
-      .joins(:mcp_tools)
-      .merge(McpTool.active.where(id: tool_ids))
-      .flat_map { it.mcp_tools.active.where(id: tool_ids).includes(:mcp_server) }
-
-    McpToolAdapter.to_llm_functions(mcp_tools)
+    McpToolAdapter.to_llm_functions(current_user.find_mcp_tools(tool_ids))
   end
 
   def format_response(result)

--- a/app/controllers/api/chats_controller.rb
+++ b/app/controllers/api/chats_controller.rb
@@ -68,7 +68,7 @@ class Api::ChatsController < ApiController
     if result.is_a?(Hash)
       result
     else
-      { message: result }
+      { message: result.to_s }
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,13 @@ class User < ApplicationRecord
     llm_api_keys.find_by(uuid: uuid)
   end
 
+  def find_mcp_tools(tool_ids)
+    mcp_servers.active
+      .joins(:mcp_tools)
+      .merge(McpTool.active.where(id: tool_ids))
+      .flat_map { it.mcp_tools.active.where(id: tool_ids).includes(:mcp_server) }
+  end
+
   def key_for(uuid)
     llm_api_key = llm_api_keys.find_by(uuid: uuid)
     return nil unless llm_api_key


### PR DESCRIPTION
## 概要

* チャットリクエスト用のMCPツールを選択するため、tool_idsパラメータを受け入れます。
* McpToolAdapterを介して変換し、LlmRbFacadeに渡します。
* McpConnectionErrorおよびMcpProtocolErrorに対するエラーハンドラを追加し、ツール呼び出しの詳細が存在する場合、応答に含めるようフォーマットします。